### PR TITLE
Migrate project toward JDA v6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.4.1_353</version>
+            <version>6.0.0-alpha.0</version>
         </dependency>
         <dependency>
-            <groupId>com.github.JDA-Applications</groupId>
-            <artifactId>JDA-Utilities</artifactId>
-            <version>c16a4b264b</version>
+            <groupId>com.jagrosh</groupId>
+            <artifactId>jda-utilities</artifactId>
+            <version>3.0.7</version>
         </dependency>
 
         <!-- Music Dependencies -->
@@ -176,7 +176,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 </project>

--- a/src/main/java/net/jellyo/jmusicbot/JMusicBot.java
+++ b/src/main/java/net/jellyo/jmusicbot/JMusicBot.java
@@ -50,7 +50,7 @@ public class JMusicBot
     public final static Permission[] RECOMMENDED_PERMS = {Permission.MESSAGE_READ, Permission.MESSAGE_WRITE, Permission.MESSAGE_HISTORY, Permission.MESSAGE_ADD_REACTION,
                                 Permission.MESSAGE_EMBED_LINKS, Permission.MESSAGE_ATTACH_FILES, Permission.MESSAGE_MANAGE, Permission.MESSAGE_EXT_EMOJI,
                                 Permission.VOICE_CONNECT, Permission.VOICE_SPEAK, Permission.NICKNAME_CHANGE};
-    public final static GatewayIntent[] INTENTS = {GatewayIntent.DIRECT_MESSAGES, GatewayIntent.GUILD_MESSAGES, GatewayIntent.GUILD_MESSAGE_REACTIONS, GatewayIntent.GUILD_VOICE_STATES};
+    public final static GatewayIntent[] INTENTS = {GatewayIntent.DIRECT_MESSAGES, GatewayIntent.GUILD_MESSAGES, GatewayIntent.GUILD_MESSAGE_REACTIONS, GatewayIntent.GUILD_VOICE_STATES, GatewayIntent.MESSAGE_CONTENT};
     
     /**
      * @param args the command line arguments
@@ -118,12 +118,11 @@ public class JMusicBot
         {
             JDA jda = JDABuilder.create(config.getToken(), Arrays.asList(INTENTS))
                     .enableCache(CacheFlag.MEMBER_OVERRIDES, CacheFlag.VOICE_STATE)
-                    .disableCache(CacheFlag.ACTIVITY, CacheFlag.CLIENT_STATUS, CacheFlag.EMOTE, CacheFlag.ONLINE_STATUS)
+                    .disableCache(CacheFlag.ACTIVITY, CacheFlag.EMOJI)
                     .setActivity(config.isGameNone() ? null : Activity.playing("loading..."))
-                    .setStatus(config.getStatus()==OnlineStatus.INVISIBLE || config.getStatus()==OnlineStatus.OFFLINE 
+                    .setStatus(config.getStatus()==OnlineStatus.INVISIBLE || config.getStatus()==OnlineStatus.OFFLINE
                             ? OnlineStatus.INVISIBLE : OnlineStatus.DO_NOT_DISTURB)
                     .addEventListeners(client, waiter, new Listener(bot))
-                    .setBulkDeleteSplittingEnabled(true)
                     .build();
             bot.setJDA(jda);
 

--- a/src/main/java/net/jellyo/jmusicbot/Listener.java
+++ b/src/main/java/net/jellyo/jmusicbot/Listener.java
@@ -20,12 +20,12 @@ import java.util.concurrent.TimeUnit;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.events.ReadyEvent;
 import net.dv8tion.jda.api.events.ShutdownEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
-import net.dv8tion.jda.api.events.message.guild.GuildMessageDeleteEvent;
+import net.dv8tion.jda.api.events.message.MessageDeleteEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -96,9 +96,12 @@ public class Listener extends ListenerAdapter
     }
     
     @Override
-    public void onGuildMessageDelete(GuildMessageDeleteEvent event) 
+    public void onMessageDelete(MessageDeleteEvent event)
     {
-        bot.getNowplayingHandler().onMessageDelete(event.getGuild(), event.getMessageIdLong());
+        if(event.isFromGuild())
+        {
+            bot.getNowplayingHandler().onMessageDelete(event.getGuild(), event.getMessageIdLong());
+        }
     }
 
     @Override

--- a/src/main/java/net/jellyo/jmusicbot/audio/AudioHandler.java
+++ b/src/main/java/net/jellyo/jmusicbot/audio/AudioHandler.java
@@ -36,11 +36,11 @@ import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioTrack;
 import java.nio.ByteBuffer;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.audio.AudioSendHandler;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -215,14 +215,14 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
 
     
     // Formatting
-    public Message getNowPlaying(JDA jda)
+    public MessageCreateData getNowPlaying(JDA jda)
     {
         if(isMusicPlaying(jda))
         {
             Guild guild = guild(jda);
             AudioTrack track = audioPlayer.getPlayingTrack();
-            MessageBuilder mb = new MessageBuilder();
-            mb.append(FormatUtil.filter(manager.getBot().getConfig().getSuccess()+" **Now Playing in "+guild.getSelfMember().getVoiceState().getChannel().getAsMention()+"...**"));
+            MessageCreateBuilder mb = new MessageCreateBuilder();
+            mb.setContent(FormatUtil.filter(manager.getBot().getConfig().getSuccess()+" **Now Playing in "+guild.getSelfMember().getVoiceState().getChannel().getAsMention()+"...**"));
             EmbedBuilder eb = new EmbedBuilder();
             eb.setColor(guild.getSelfMember().getColor());
             RequestMetadata rm = getRequestMetadata();
@@ -262,11 +262,11 @@ public class AudioHandler extends AudioEventAdapter implements AudioSendHandler
         }
         else return null;
     }
-    
-    public Message getNoMusicPlaying(JDA jda)
+
+    public MessageCreateData getNoMusicPlaying(JDA jda)
     {
         Guild guild = guild(jda);
-        return new MessageBuilder()
+        return new MessageCreateBuilder()
                 .setContent(FormatUtil.filter(manager.getBot().getConfig().getSuccess()+" **Now Playing...**"))
                 .setEmbeds(new EmbedBuilder()
                 .setTitle("No music playing")

--- a/src/main/java/net/jellyo/jmusicbot/audio/NowplayingHandler.java
+++ b/src/main/java/net/jellyo/jmusicbot/audio/NowplayingHandler.java
@@ -27,9 +27,10 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.exceptions.PermissionException;
-import net.dv8tion.jda.api.exceptions.RateLimitedException;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageEditData;
 
 /**
  *
@@ -54,7 +55,7 @@ public class NowplayingHandler
     
     public void setLastNPMessage(Message m)
     {
-        lastNP.put(m.getGuild().getIdLong(), new Pair<>(m.getTextChannel().getIdLong(), m.getIdLong()));
+        lastNP.put(m.getGuild().getIdLong(), new Pair<>(m.getGuildChannel().getIdLong(), m.getIdLong()));
     }
     
     public void clearLastNPMessage(Guild guild)
@@ -81,19 +82,24 @@ public class NowplayingHandler
                 continue;
             }
             AudioHandler handler = (AudioHandler)guild.getAudioManager().getSendingHandler();
-            Message msg = handler.getNowPlaying(bot.getJDA());
+            MessageCreateData msg = handler.getNowPlaying(bot.getJDA());
             if(msg==null)
             {
                 msg = handler.getNoMusicPlaying(bot.getJDA());
                 toRemove.add(guildId);
             }
-            try 
+            if(msg != null)
             {
-                tc.editMessageById(pair.getValue(), msg).queue(m->{}, t -> lastNP.remove(guildId));
-            } 
-            catch(Exception e) 
-            {
-                toRemove.add(guildId);
+                MessageEditBuilder builder = MessageEditBuilder.fromCreateData(msg);
+                MessageEditData data = builder.build();
+                try
+                {
+                    tc.editMessageById(pair.getValue(), data).queue(m->{}, t -> lastNP.remove(guildId));
+                }
+                catch(Exception e)
+                {
+                    toRemove.add(guildId);
+                }
             }
         }
         toRemove.forEach(id -> lastNP.remove(id));

--- a/src/main/java/net/jellyo/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/MusicCommand.java
@@ -20,9 +20,10 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
-import net.dv8tion.jda.api.entities.GuildVoiceState;
-import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.MemberVoiceState;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 
 /**
@@ -64,32 +65,33 @@ public abstract class MusicCommand extends Command
         }
         if(beListening)
         {
-            VoiceChannel current = event.getGuild().getSelfMember().getVoiceState().getChannel();
+            AudioChannelUnion current = event.getGuild().getSelfMember().getVoiceState().getChannel();
             if(current==null)
                 current = settings.getVoiceChannel(event.getGuild());
-            GuildVoiceState userState = event.getMember().getVoiceState();
-            if(!userState.inVoiceChannel() || userState.isDeafened() || (current!=null && !userState.getChannel().equals(current)))
+            MemberVoiceState userState = event.getMember().getVoiceState();
+            AudioChannelUnion userChannel = userState == null ? null : userState.getChannel();
+            if(userState == null || userChannel == null || !userState.inAudioChannel() || userState.isDeafened() || (current!=null && userChannel.getIdLong()!=current.getIdLong()))
             {
                 event.replyError("You must be listening in "+(current==null ? "a voice channel" : current.getAsMention())+" to use that!");
                 return;
             }
 
             VoiceChannel afkChannel = userState.getGuild().getAfkChannel();
-            if(afkChannel != null && afkChannel.equals(userState.getChannel()))
+            if(afkChannel != null && afkChannel.getIdLong() == userChannel.getIdLong())
             {
                 event.replyError("You cannot use that command in an AFK channel!");
                 return;
             }
 
-            if(!event.getGuild().getSelfMember().getVoiceState().inVoiceChannel())
+            if(!event.getGuild().getSelfMember().getVoiceState().inAudioChannel())
             {
-                try 
+                try
                 {
-                    event.getGuild().getAudioManager().openAudioConnection(userState.getChannel());
+                    event.getGuild().getAudioManager().openAudioConnection(userChannel);
                 }
-                catch(PermissionException ex) 
+                catch(PermissionException ex)
                 {
-                    event.reply(event.getClient().getError()+" I am unable to connect to "+userState.getChannel().getAsMention()+"!");
+                    event.reply(event.getClient().getError()+" I am unable to connect to "+userChannel.getAsMention()+"!");
                     return;
                 }
             }

--- a/src/main/java/net/jellyo/jmusicbot/commands/admin/SettcCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/admin/SettcCmd.java
@@ -22,7 +22,7 @@ import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 
 /**
  *

--- a/src/main/java/net/jellyo/jmusicbot/commands/admin/SetvcCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/admin/SetvcCmd.java
@@ -22,7 +22,7 @@ import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.AdminCommand;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 
 /**
  *

--- a/src/main/java/net/jellyo/jmusicbot/commands/general/SettingsCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/general/SettingsCmd.java
@@ -23,10 +23,10 @@ import com.jagrosh.jmusicbot.settings.RepeatMode;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 
 /**
  *
@@ -48,10 +48,8 @@ public class SettingsCmd extends Command
     protected void execute(CommandEvent event) 
     {
         Settings s = event.getClient().getSettingsFor(event.getGuild());
-        MessageBuilder builder = new MessageBuilder()
-                .append(EMOJI + " **")
-                .append(FormatUtil.filter(event.getSelfUser().getName()))
-                .append("** settings:");
+        MessageCreateBuilder builder = new MessageCreateBuilder()
+                .setContent(EMOJI + " **" + FormatUtil.filter(event.getSelfUser().getName()) + "** settings:");
         TextChannel tchan = s.getTextChannel(event.getGuild());
         VoiceChannel vchan = s.getVoiceChannel(event.getGuild());
         Role role = s.getRole(event.getGuild());

--- a/src/main/java/net/jellyo/jmusicbot/commands/music/NowplayingCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/music/NowplayingCmd.java
@@ -20,7 +20,7 @@ import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.audio.AudioHandler;
 import com.jagrosh.jmusicbot.commands.MusicCommand;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 
 /**
  *
@@ -41,15 +41,15 @@ public class NowplayingCmd extends MusicCommand
     public void doCommand(CommandEvent event) 
     {
         AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
-        Message m = handler.getNowPlaying(event.getJDA());
-        if(m==null)
+        MessageCreateData data = handler.getNowPlaying(event.getJDA());
+        if(data==null)
         {
-            event.reply(handler.getNoMusicPlaying(event.getJDA()));
+            event.getChannel().sendMessage(handler.getNoMusicPlaying(event.getJDA())).queue();
             bot.getNowplayingHandler().clearLastNPMessage(event.getGuild());
         }
         else
         {
-            event.reply(m, msg -> bot.getNowplayingHandler().setLastNPMessage(msg));
+            event.getChannel().sendMessage(data).queue(msg -> bot.getNowplayingHandler().setLastNPMessage(msg));
         }
     }
 }

--- a/src/main/java/net/jellyo/jmusicbot/commands/music/QueueCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/music/QueueCmd.java
@@ -28,10 +28,11 @@ import com.jagrosh.jmusicbot.settings.RepeatMode;
 import com.jagrosh.jmusicbot.settings.Settings;
 import com.jagrosh.jmusicbot.utils.FormatUtil;
 import com.jagrosh.jmusicbot.utils.TimeUtil;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.exceptions.PermissionException;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 
 /**
  *
@@ -75,12 +76,15 @@ public class QueueCmd extends MusicCommand
         List<QueuedTrack> list = ah.getQueue().getList();
         if(list.isEmpty())
         {
-            Message nowp = ah.getNowPlaying(event.getJDA());
-            Message nonowp = ah.getNoMusicPlaying(event.getJDA());
-            Message built = new MessageBuilder()
-                    .setContent(event.getClient().getWarning() + " There is no music in the queue!")
-                    .setEmbeds((nowp==null ? nonowp : nowp).getEmbeds().get(0)).build();
-            event.reply(built, m -> 
+            MessageCreateData nowp = ah.getNowPlaying(event.getJDA());
+            MessageCreateData nonowp = ah.getNoMusicPlaying(event.getJDA());
+            MessageCreateBuilder builder = new MessageCreateBuilder()
+                    .setContent(event.getClient().getWarning() + " There is no music in the queue!");
+            MessageCreateData base = nowp==null ? nonowp : nowp;
+            if(base != null && !base.getEmbeds().isEmpty())
+                builder.setEmbeds(base.getEmbeds().toArray(new MessageEmbed[0]));
+            MessageCreateData built = builder.build();
+            event.getChannel().sendMessage(built).queue(m ->
             {
                 if(nowp!=null)
                     bot.getNowplayingHandler().setLastNPMessage(m);

--- a/src/main/java/net/jellyo/jmusicbot/commands/owner/DebugCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/owner/DebugCmd.java
@@ -23,7 +23,7 @@ import com.jagrosh.jmusicbot.utils.OtherUtil;
 import com.sedmelluq.discord.lavaplayer.tools.PlayerLibrary;
 import net.dv8tion.jda.api.JDAInfo;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
 
 /**
  *

--- a/src/main/java/net/jellyo/jmusicbot/commands/owner/EvalCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/owner/EvalCmd.java
@@ -20,7 +20,7 @@ import javax.script.ScriptEngineManager;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
-import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
 
 /**
  *

--- a/src/main/java/net/jellyo/jmusicbot/commands/owner/SetnameCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/owner/SetnameCmd.java
@@ -18,7 +18,8 @@ package com.jagrosh.jmusicbot.commands.owner;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jagrosh.jmusicbot.Bot;
 import com.jagrosh.jmusicbot.commands.OwnerCommand;
-import net.dv8tion.jda.api.exceptions.RateLimitedException;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 
 /**
  *
@@ -44,11 +45,14 @@ public class SetnameCmd extends OwnerCommand
             event.getSelfUser().getManager().setName(event.getArgs()).complete(false);
             event.reply(event.getClient().getSuccess()+" Name changed from `"+oldname+"` to `"+event.getArgs()+"`");
         } 
-        catch(RateLimitedException e) 
+        catch(ErrorResponseException e)
         {
-            event.reply(event.getClient().getError()+" Name can only be changed twice per hour!");
+            if(e.getErrorResponse() == ErrorResponse.RATE_LIMITED)
+                event.reply(event.getClient().getError()+" Name can only be changed twice per hour!");
+            else
+                event.reply(event.getClient().getError()+" That name is not valid!");
         }
-        catch(Exception e) 
+        catch(Exception e)
         {
             event.reply(event.getClient().getError()+" That name is not valid!");
         }

--- a/src/main/java/net/jellyo/jmusicbot/settings/Settings.java
+++ b/src/main/java/net/jellyo/jmusicbot/settings/Settings.java
@@ -20,8 +20,8 @@ import java.util.Collection;
 import java.util.Collections;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 
 /**
  *

--- a/src/main/java/net/jellyo/jmusicbot/utils/FormatUtil.java
+++ b/src/main/java/net/jellyo/jmusicbot/utils/FormatUtil.java
@@ -18,9 +18,9 @@ package com.jagrosh.jmusicbot.utils;
 import com.jagrosh.jmusicbot.audio.RequestMetadata.UserInfo;
 import java.util.List;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 
 /**
  *


### PR DESCRIPTION
## Summary
- bump the Discord dependencies to target JDA v6 pre-release builds and align the project with Java 17
- refresh bot bootstrap code to request message content intent and drop deprecated cache / bulk delete toggles
- migrate message creation, queue displays, and now playing updates onto the new MessageCreate/MessageEdit APIs while updating channel typings
- adjust voice-state checks and owner tooling to use the latest JDA types and error handling

## Testing
- `mvn -q -DskipTests package` *(fails: dependency downloads blocked by 403 responses from https://m2.dv8tion.net)*

------
https://chatgpt.com/codex/tasks/task_e_6903a23821dc832ea0c513d4d5375f46