### PR TITLE
Add slash command support for existing commands

### DIFF
--- a/src/main/java/net/jellyo/jmusicbot/JMusicBot.java
+++ b/src/main/java/net/jellyo/jmusicbot/JMusicBot.java
@@ -122,7 +122,7 @@ public class JMusicBot
                     .setActivity(config.isGameNone() ? null : Activity.playing("loading..."))
                     .setStatus(config.getStatus()==OnlineStatus.INVISIBLE || config.getStatus()==OnlineStatus.OFFLINE 
                             ? OnlineStatus.INVISIBLE : OnlineStatus.DO_NOT_DISTURB)
-                    .addEventListeners(client, waiter, new Listener(bot))
+                    .addEventListeners(client, waiter, new Listener(bot), new SlashCommandListener(client))
                     .setBulkDeleteSplittingEnabled(true)
                     .build();
             bot.setJDA(jda);

--- a/src/main/java/net/jellyo/jmusicbot/SlashCommandAdapter.java
+++ b/src/main/java/net/jellyo/jmusicbot/SlashCommandAdapter.java
@@ -1,0 +1,133 @@
+package com.jagrosh.jmusicbot;
+
+import com.jagrosh.jdautilities.command.CommandClient;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+
+/**
+ * A simple adapter to allow existing {@link CommandEvent}-based commands to be reused for slash commands.
+ */
+public class SlashCommandAdapter extends CommandEvent
+{
+    private final SlashCommandInteractionEvent slashEvent;
+
+    public SlashCommandAdapter(SlashCommandInteractionEvent event, String args, CommandClient client)
+    {
+        super((MessageReceivedEvent) null, args, client);
+        this.slashEvent = event;
+    }
+
+    @Override
+    public Guild getGuild()
+    {
+        return slashEvent.getGuild();
+    }
+
+    @Override
+    public Member getMember()
+    {
+        return slashEvent.getMember();
+    }
+
+    @Override
+    public Member getSelfMember()
+    {
+        return slashEvent.getGuild() == null ? null : slashEvent.getGuild().getSelfMember();
+    }
+
+    @Override
+    public User getAuthor()
+    {
+        return slashEvent.getUser();
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return slashEvent.getJDA();
+    }
+
+    @Override
+    public MessageChannel getChannel()
+    {
+        MessageChannelUnion channel = slashEvent.getChannel();
+        return channel == null ? null : channel.asGuildMessageChannel();
+    }
+
+    @Override
+    public TextChannel getTextChannel()
+    {
+        MessageChannelUnion channel = slashEvent.getChannel();
+        return channel == null ? null : channel.asTextChannel();
+    }
+
+    @Override
+    public ChannelType getChannelType()
+    {
+        return slashEvent.getChannelType();
+    }
+
+    @Override
+    public void reply(String message)
+    {
+        slashEvent.reply(message).queue();
+    }
+
+    @Override
+    public void replyWarning(String message)
+    {
+        slashEvent.reply(getClient().getWarning() + message).queue();
+    }
+
+    @Override
+    public void replySuccess(String message)
+    {
+        slashEvent.reply(getClient().getSuccess() + message).queue();
+    }
+
+    @Override
+    public void replyError(String message)
+    {
+        slashEvent.reply(getClient().getError() + message).queue();
+    }
+
+    @Override
+    public void replyInDm(String message)
+    {
+        slashEvent.getUser().openPrivateChannel().queue(pc -> pc.sendMessage(message).queue());
+    }
+
+    @Override
+    public void replyInDm(String message, java.util.function.Consumer<Message> success, java.util.function.Consumer<Throwable> failure)
+    {
+        slashEvent.getUser().openPrivateChannel().queue(pc -> pc.sendMessage(message).queue(success, failure), failure);
+    }
+
+    @Override
+    public boolean isFromType(ChannelType type)
+    {
+        return getChannelType() == type;
+    }
+
+    @Override
+    public Message getMessage()
+    {
+        return null;
+    }
+
+    public OptionMapping getOption(String name)
+    {
+        return slashEvent.getOption(name);
+    }
+}

--- a/src/main/java/net/jellyo/jmusicbot/SlashCommandAdapter.java
+++ b/src/main/java/net/jellyo/jmusicbot/SlashCommandAdapter.java
@@ -3,17 +3,17 @@ package com.jagrosh.jmusicbot;
 import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 
 /**
  * A simple adapter to allow existing {@link CommandEvent}-based commands to be reused for slash commands.
@@ -24,7 +24,7 @@ public class SlashCommandAdapter extends CommandEvent
 
     public SlashCommandAdapter(SlashCommandInteractionEvent event, String args, CommandClient client)
     {
-        super((MessageReceivedEvent) null, args, client);
+        super((MessageReceivedEvent) null, "", args, client);
         this.slashEvent = event;
     }
 

--- a/src/main/java/net/jellyo/jmusicbot/SlashCommandListener.java
+++ b/src/main/java/net/jellyo/jmusicbot/SlashCommandListener.java
@@ -1,0 +1,58 @@
+package com.jagrosh.jmusicbot;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandClient;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.session.ReadyEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.CommandListUpdateAction;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+/**
+ * Registers slash commands and forwards interactions to existing command implementations.
+ */
+public class SlashCommandListener extends ListenerAdapter
+{
+    private final CommandClient commandClient;
+
+    public SlashCommandListener(CommandClient commandClient)
+    {
+        this.commandClient = commandClient;
+    }
+
+    @Override
+    public void onReady(@NotNull ReadyEvent event)
+    {
+        CommandListUpdateAction updateAction = event.getJDA().updateCommands();
+        Arrays.stream(commandClient.getCommands()).forEach(command -> updateAction.addCommands(buildSlashData(command)));
+        updateAction.queue();
+    }
+
+    @Override
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event)
+    {
+        Command target = Arrays.stream(commandClient.getCommands())
+                .filter(cmd -> cmd.getName().equalsIgnoreCase(event.getName()) || Arrays.asList(cmd.getAliases() == null ? new String[0] : cmd.getAliases()).contains(event.getName()))
+                .findFirst()
+                .orElse(null);
+        if(target == null)
+            return;
+
+        String args = event.getOption("input", "", option -> option.getAsString());
+        CommandEvent adapter = new SlashCommandAdapter(event, args, commandClient);
+        target.run(adapter);
+    }
+
+    private SlashCommandData buildSlashData(Command command)
+    {
+        SlashCommandData data = Commands.slash(command.getName(), command.getHelp() == null ? "No description" : command.getHelp());
+        data.addOption(OptionType.STRING, "input", command.getArguments() == null ? "Command arguments" : command.getArguments(), false);
+        return data;
+    }
+}

--- a/src/main/java/net/jellyo/jmusicbot/SlashCommandListener.java
+++ b/src/main/java/net/jellyo/jmusicbot/SlashCommandListener.java
@@ -7,9 +7,9 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.events.session.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
-import net.dv8tion.jda.api.interactions.commands.build.CommandListUpdateAction;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -30,14 +30,14 @@ public class SlashCommandListener extends ListenerAdapter
     public void onReady(@NotNull ReadyEvent event)
     {
         CommandListUpdateAction updateAction = event.getJDA().updateCommands();
-        Arrays.stream(commandClient.getCommands()).forEach(command -> updateAction.addCommands(buildSlashData(command)));
+        commandClient.getCommands().forEach(command -> updateAction.addCommands(buildSlashData(command)));
         updateAction.queue();
     }
 
     @Override
     public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event)
     {
-        Command target = Arrays.stream(commandClient.getCommands())
+        Command target = commandClient.getCommands().stream()
                 .filter(cmd -> cmd.getName().equalsIgnoreCase(event.getName()) || Arrays.asList(cmd.getAliases() == null ? new String[0] : cmd.getAliases()).contains(event.getName()))
                 .findFirst()
                 .orElse(null);

--- a/src/main/java/net/jellyo/jmusicbot/commands/MusicCommand.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/MusicCommand.java
@@ -50,9 +50,10 @@ public abstract class MusicCommand extends Command
         TextChannel tchannel = settings.getTextChannel(event.getGuild());
         if(tchannel!=null && !event.getTextChannel().equals(tchannel))
         {
-            try 
+            try
             {
-                event.getMessage().delete().queue();
+                if(event.getMessage()!=null)
+                    event.getMessage().delete().queue();
             } catch(PermissionException ignore){}
             event.replyInDm(event.getClient().getError()+" You can only use that command in "+tchannel.getAsMention()+"!");
             return;

--- a/src/main/java/net/jellyo/jmusicbot/commands/dj/PlaynextCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/dj/PlaynextCmd.java
@@ -52,14 +52,14 @@ public class PlaynextCmd extends DJCommand
     @Override
     public void doCommand(CommandEvent event)
     {
-        if(event.getArgs().isEmpty() && event.getMessage().getAttachments().isEmpty())
+        if(event.getArgs().isEmpty() && (event.getMessage()==null || event.getMessage().getAttachments().isEmpty()))
         {
             event.replyWarning("Please include a song title or URL!");
             return;
         }
-        String args = event.getArgs().startsWith("<") && event.getArgs().endsWith(">") 
-                ? event.getArgs().substring(1,event.getArgs().length()-1) 
-                : event.getArgs().isEmpty() ? event.getMessage().getAttachments().get(0).getUrl() : event.getArgs();
+        String args = event.getArgs().startsWith("<") && event.getArgs().endsWith(">")
+                ? event.getArgs().substring(1,event.getArgs().length()-1)
+                : event.getArgs().isEmpty() && event.getMessage()!=null ? event.getMessage().getAttachments().get(0).getUrl() : event.getArgs();
         event.reply(loadingEmoji+" Loading... `["+args+"]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m,event,false)));
     }
     

--- a/src/main/java/net/jellyo/jmusicbot/commands/music/PlayCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/music/PlayCmd.java
@@ -64,7 +64,7 @@ public class PlayCmd extends MusicCommand
     @Override
     public void doCommand(CommandEvent event) 
     {
-        if(event.getArgs().isEmpty() && event.getMessage().getAttachments().isEmpty())
+        if(event.getArgs().isEmpty() && (event.getMessage()==null || event.getMessage().getAttachments().isEmpty()))
         {
             AudioHandler handler = (AudioHandler)event.getGuild().getAudioManager().getSendingHandler();
             if(handler.getPlayer().getPlayingTrack()!=null && handler.getPlayer().isPaused())
@@ -86,9 +86,9 @@ public class PlayCmd extends MusicCommand
             event.reply(builder.toString());
             return;
         }
-        String args = event.getArgs().startsWith("<") && event.getArgs().endsWith(">") 
-                ? event.getArgs().substring(1,event.getArgs().length()-1) 
-                : event.getArgs().isEmpty() ? event.getMessage().getAttachments().get(0).getUrl() : event.getArgs();
+        String args = event.getArgs().startsWith("<") && event.getArgs().endsWith(">")
+                ? event.getArgs().substring(1,event.getArgs().length()-1)
+                : event.getArgs().isEmpty() && event.getMessage()!=null ? event.getMessage().getAttachments().get(0).getUrl() : event.getArgs();
         event.reply(loadingEmoji+" Loading... `["+args+"]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m,event,false)));
     }
     

--- a/src/main/java/net/jellyo/jmusicbot/commands/music/PlaytopCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/music/PlaytopCmd.java
@@ -38,14 +38,14 @@ public class PlaytopCmd extends MusicCommand
     @Override
     public void doCommand(CommandEvent event)
     {
-        if(event.getArgs().isEmpty() && event.getMessage().getAttachments().isEmpty())
+        if(event.getArgs().isEmpty() && (event.getMessage()==null || event.getMessage().getAttachments().isEmpty()))
         {
             event.replyWarning("Please include a song title or URL!");
             return;
         }
         String args = event.getArgs().startsWith("<") && event.getArgs().endsWith(">")
                 ? event.getArgs().substring(1,event.getArgs().length()-1)
-                : event.getArgs().isEmpty() ? event.getMessage().getAttachments().get(0).getUrl() : event.getArgs();
+                : event.getArgs().isEmpty() && event.getMessage()!=null ? event.getMessage().getAttachments().get(0).getUrl() : event.getArgs();
         event.reply(loadingEmoji+" Loading... `["+args+"]`", m -> bot.getPlayerManager().loadItemOrdered(event.getGuild(), args, new ResultHandler(m,event,false)));
     }
 

--- a/src/main/java/net/jellyo/jmusicbot/commands/owner/SetavatarCmd.java
+++ b/src/main/java/net/jellyo/jmusicbot/commands/owner/SetavatarCmd.java
@@ -43,7 +43,7 @@ public class SetavatarCmd extends OwnerCommand
     {
         String url;
         if(event.getArgs().isEmpty())
-            if(!event.getMessage().getAttachments().isEmpty() && event.getMessage().getAttachments().get(0).isImage())
+            if(event.getMessage()!=null && !event.getMessage().getAttachments().isEmpty() && event.getMessage().getAttachments().get(0).isImage())
                 url = event.getMessage().getAttachments().get(0).getUrl();
             else
                 url = null;


### PR DESCRIPTION
## Summary
- add slash command listener that registers commands on ready and routes interactions to existing handlers
- adapt command handling to tolerate missing message attachments for slash invocations
- keep legacy prefix commands while enabling slash command usage across the bot

## Testing
- mvn -q -DskipTests package *(fails: repository access to https://m2.chew.pro/releases returned 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69342543cd98832e8c8d39b75d0669e6)